### PR TITLE
#Issue22: Get MPI with cuda support working with mpiT

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ mpirun -np 12 th mlaunch.lua
 - The implementation of *msgd*, *downpour*, *easgd* and *eamsgd* is added.
 - The starting offset in pclient.lua is set to 1 rather than 0, for current Torch7's support.
 - Use `mpiT.Cancel` to release the buffer ownership on io stop in `mpiT.aio_read` and `mpiT.aio_recv`.
-
+- To run mpiT with cuda support, configure and install MPI with cuda support and add MPI library path to environment variable `LD_LIBRARY_PATH=${MPI_PREFIX}/lib:$LD_LIBRARY_PATH`
 
 ## Reference
 

--- a/asyncsgd/mlaunch.lua
+++ b/asyncsgd/mlaunch.lua
@@ -2,7 +2,8 @@
 -- Author: Sixin Zhang (zsx@cims.nyu.edu)
 -- mpirun -n 12 luajit mlaunch.lua
 local oncuda = false
-
+local ffi = require("ffi")
+ffi.load("libmpi",true)
 local AGPU = nil
 if oncuda then
    require 'cutorch'

--- a/asyncsgd/ptest.lua
+++ b/asyncsgd/ptest.lua
@@ -2,7 +2,8 @@
 
 local ssize = 10*4096*4096
 local usecuda = false
-
+local ffi = require("ffi")
+ffi.load("libmpi",true)
 require 'mpiT'
 dofile('init.lua')
 mpiT.Init()

--- a/test.lua
+++ b/test.lua
@@ -1,4 +1,6 @@
 --Torch lib for mpi commnication
+local ffi = require("ffi")
+ffi.load("libmpi",true)
 
 require 'mpiT'
 


### PR DESCRIPTION
Added

    local ffi = require("ffi")
    ffi.load("libmpi",true)

to following files

- test.lua
- asyncsgd/ptest.lua
- asyncsgd/mlaunch.lua